### PR TITLE
Fixes empty XNAT keyword bug by applying string strip

### DIFF
--- a/src/xnatdcat/xnat_parser.py
+++ b/src/xnatdcat/xnat_parser.py
@@ -37,7 +37,7 @@ def xnat_to_DCATDataset(project: XNATSession, config: Dict) -> DCATDataSet:
     # can be used independently as a search string.
     keywords = None
     if xnat_keywords := project.keywords:
-        keywords = [Literal(kw.strip()) for kw in xnat_keywords.split(" ")]
+        keywords = [Literal(kw.strip()) for kw in xnat_keywords.strip().split(" ")]
 
     if not (project.pi.firstname or project.pi.lastname):
         raise ValueError("Cannot have empty name of PI")


### PR DESCRIPTION
Previously XNAT keywords that started or ended in a whitespace resulted in empty dcat:keyword entries, resulting in errors during ingestion into the catalogue. This has been fixed by applying a string strip on the XNAT keywords before splitting them on the space character.