### PR TITLE
[EUCAIM-56] Allow usage of environment variable for specifying xnat server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ to be a separate Dataset.
 
 ## Installation
 
+This tool requires an installation of Python 3.8 or higher.
 Download a wheel file from releases and install using `pip install`. The tool can then be run by
 running the `xnatdcat` command from the commandline.
 
@@ -12,7 +13,7 @@ running the `xnatdcat` command from the commandline.
 
 Basic example: `xnatdcat https://xnat.bmia.nl`; output will appear at stdout.
 
-The tool supports both public and privat XNAT instances. For authentication, you can either supply
+The tool supports both public and private XNAT instances. For authentication, you can either supply
 a username and/or password at the commandline or use a `.netrc` file. For more information regarding
 this, see the [XNATpy documentation](https://xnat.readthedocs.io/en/latest/static/tutorial.html#credentials).
 
@@ -20,21 +21,23 @@ By default, output of the tool is in turtle format at stdout to make for easy pi
 written in a variety of formats to a file, too. For all options, see `xnatdcat --help`:
 
 ```text
-usage: xnatdcat [-h] [-u USERNAME] [-p PASSWORD] [-o OUTPUT] [-f FORMAT] [-V] server
+usage: xnatdcat [-h] [-u USERNAME] [-p PASSWORD] [-o OUTPUT] [-f FORMAT] [-c CONFIG] [-V] [server]
 
 This tool generates DCAT from XNAT
 
 positional arguments:
-  server                URI of the server to connect to (including http:// or https://)
+  server                URI of the server to connect to (including http:// or https://). If not
+                        set, will use environment variables.
 
 options:
   -h, --help            show this help message and exit
   -u USERNAME, --username USERNAME
-                        Username to use, leave empty to use netrc entry or anonymous login.
+                        Username to use, leave empty to use netrc entry or anonymous login or
+                        environment variables.
   -p PASSWORD, --password PASSWORD
                         Password to use with the username, leave empty when using netrc. If a
-                        username is given and no password, there will be a prompt on the console
-                        requesting the password.
+                        username is given and no password or environment variable, there will be a
+                        prompt on the console requesting the password.
   -o OUTPUT, --output OUTPUT
                         Destination file to write output to. If not set, the script will print
                         serialized output to stdout.
@@ -59,6 +62,12 @@ example file will be used.
 A limited number of properties can be set in the configuration, including the title and name of the
 xnat (DCAT) catalog and the publisher of the catalog. We are still working on adding more default
 values for certain DCAT properties to the configuration.
+
+There is limited support for using environment variables. For setting the XNAT server, variables
+`XNAT_HOST` and `XNATPY_HOST` can be used. When setting `XNAT_HOST`, authentication
+*must* be provided in `XNAT_USER` and `XNAT_PASS`, else anonymous login will be used. When using
+`XNATPY_HOST`, environment variables cannot be used for authentication (use netrc entry or
+the commandline).
 
 ## Development
 

--- a/src/xnatdcat/cli_app.py
+++ b/src/xnatdcat/cli_app.py
@@ -27,14 +27,18 @@ def __parse_cli_args():
     parser.add_argument(
         "server",
         type=str,
-        help="URI of the server to connect to (including http:// or https://)",
+        help=(
+            "URI of the server to connect to (including http:// or https://). If not set, will use "
+            "environment variables."
+        ),
+        nargs="?",
     )
     parser.add_argument(
         "-u",
         "--username",
         default=None,
         type=str,
-        help="Username to use, leave empty to use netrc entry or anonymous login.",
+        help="Username to use, leave empty to use netrc entry or anonymous login or environment variables.",
     )
     parser.add_argument(
         "-p",
@@ -43,7 +47,7 @@ def __parse_cli_args():
         type=str,
         help=(
             "Password to use with the username, leave empty when using netrc. If a"
-            " username is given and no password, there will be a prompt on the console"
+            " username is given and no password or environment variable, there will be a prompt on the console"
             " requesting the password."
         ),
     )


### PR DESCRIPTION
See title. There is a few limitations (unintended behavior?) in xnatpy, so I documented it.