### PR TITLE
[EUCAIM-50] keyword based opt-in / opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ running the `xnatdcat` command from the commandline.
 
 ## Usage
 
-Basic example: `xnatdcat https://xnat.bmia.nl`; output will appear at stdout. A log file `xnatdcat.log` will be 
+Basic example: `xnatdcat https://xnat.bmia.nl`; output will appear at stdout. A log file `xnatdcat.log` will be
 created in the directory from which you run this program.
 
 The tool supports both public and private XNAT instances. For authentication, you can either supply
@@ -70,6 +70,20 @@ provided in `XNAT_USER` and `XNAT_PASS`.
 
 Commandline arguments take precedence over environment variables. Environment variables take
 precedence over `.netrc` login.
+
+## Inclusion and exclusion of projects
+
+By default, all public and protected projects are indexed. Private projects are *not* indexed, even
+if you provide user credentials that have relevant permissions for them.
+
+Further granularity can be provided by using keywords. There is functionality for an opt-in keyword
+and an opt-out keyword, though only one of these at the time. If an opt-in keyword is set, only
+projects containing this magic keyword in their metadata will be indexed. All other projects will be
+ignored. If an opt-out keyword is set, all projects except for those containing the magic opt-out
+keyword will be indexed. The keywords can be configured in either the settings or the CLI, see the
+example configuration file.
+
+Note that private projects will never be indexed, not even if an opt-in keyword is set in them.
 
 ## Development
 

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,3 +1,7 @@
+[xnatdcat]
+# optin = "include_catalog"
+# optout = "exclude_catalog"
+
 [catalog]
 title = "Example XNAT catalog"
 description = "This is an example XNAT catalog description"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-mock", "requests-mock"]
+dependencies = ["pytest", "pytest-mock", "requests-mock", "pytest-cov"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/src/xnatdcat/cli_app.py
+++ b/src/xnatdcat/cli_app.py
@@ -196,12 +196,9 @@ def run_cli_app():
 
     config = load_configuration(args.config)
 
-    if args.optin:
+    if args.optin or args.optout:
         config['xnatdcat']['optin'] = args.optin
-        config['xnatdcat']['optout'] = None
-    if args.optout:
         config['xnatdcat']['optout'] = args.optout
-        config['xnatdcat']['optin'] = None
 
     with __connect_xnat(args) as session:
         g = xnat_to_RDF(session, config)

--- a/tests/test_optin_optout.py
+++ b/tests/test_optin_optout.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+import pytest
+
+from xnatdcat.xnat_parser import _check_optin_optout, split_keywords
+
+
+@pytest.mark.parametrize(
+    "test_str, expected",
+    [
+        # Various type of whitespace and variations
+        ('', []),
+        ('        ', []),
+        # Keywords with different amounts of space inbetween
+        ('xnat python', ['xnat', 'python']),
+        ('  xnat      python ', ['xnat', 'python']),
+        # Below is real example. The official XNAT specification is not followed by the writer
+        ('artificial intelligence, radiomics', ['artificial', 'intelligence', 'radiomics']),
+        # Some random punctuations and stuff
+        ('artificial;intelligence.   radiomics', ['artificial', 'intelligence', 'radiomics']),
+        ('artificial ; intelligence.,.,.,radiomics', ['artificial', 'intelligence', 'radiomics']),
+    ],
+)
+def test_keyword_splitter(test_str, expected):
+    output_list = split_keywords(test_str)
+
+    # We compare it as a set as we do not care about the order (the RDF serializer mangles it anyways)
+    assert set(expected) == set(output_list)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_no_optin_optout(project):
+    project.keywords = 'test demo optout_keyword'
+    config = {'xnatdcat': dict()}
+
+    # First test no config
+    assert _check_optin_optout(project, config)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_optout(project):
+    # project without keywords
+    config = {'xnatdcat': {'optout': 'optout_keyword'}}
+    assert _check_optin_optout(project, config)
+
+    project.keywords = 'test demo optout_keyword'
+    assert not _check_optin_optout(project, config)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_optin(project):
+    config = {'xnatdcat': {'optin': 'optin_keyword'}}
+    project.keywords = 'test demo optin_keyword'
+
+    assert _check_optin_optout(project, config)
+
+    project.keywords = 'test demo'
+    assert not _check_optin_optout(project, config)
+
+    # assert to_isomorphic(empty_graph) == to_isomorphic(gen)


### PR DESCRIPTION
As a Regional Node, I want to make sure only the correct XNAT projects end up in a metadata catalog. Test projects are present in every XNAT and should not be indexed or harvested. Therefore, there should be a way to either exclude certain projects or specifically include them. In XNAT it is possible to add certain keywords to a dataset, this mechanism would be the easiest to indicate whether a dataset should be included.

Acceptance criteria:
* A ‘blacklist’ keyword can be specified and no projects containing this keyword are indexed
* A ‘whitelist’ keyword can be specified and only projects containing this keyword are indexed
* If both keywords are specified, an error is thrown