### PR TITLE
Codecov integration

### DIFF
--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -38,4 +38,9 @@ jobs:
     #    #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        hatch run +py=${{ matrix.python-version }} test:test --doctest-modules --junitxml=junit/test-results.xml
+        hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # XNAT to DCAT-AP
 
+![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FHealth-RI%2Fxnatdcat%2Fmain%2Fpyproject.toml)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Health-RI/xnatdcat/python-test-package.yml)
+![Codecov](https://img.shields.io/codecov/c/github/Health-RI/xnatdcat)
+
 This tool queries an XNAT instance and generates DCAT-AP 3.0 metadata. Every XNAT project is considered
 to be a separate Dataset. Only 'public' and 'protected' datasets are queried.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = ["coverage[toml]>=6.5", "pytest"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
-cov-report = ["- coverage combine", "coverage report"]
+cov-report = ["- coverage combine", "coverage report", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 
 [tool.hatch.envs.test]
@@ -136,7 +136,7 @@ ban-relative-imports = "all"
 source_pkgs = ["xnatdcat", "tests"]
 branch = true
 parallel = true
-omit = ["src/xnatdcat/__about__.py"]
+omit = ["src/xnatdcat/__about__.py", "src/xnatdcat/__main__.py"]
 
 [tool.coverage.paths]
 xnatdcat = ["src/xnatdcat", "*/xnatdcat/src/xnatdcat"]


### PR DESCRIPTION
This pull requests adds codecov support and show results on the main project page.

Note: prerequisite is that the codecov github app is activated for our team. It's free for public (open source) repositories, and as we are open source it should be good.

No story attached as I kinda wanted to meddle with this in my own time :)