### PR TITLE
[EUCAIM-77] Allow a generic contact point for all datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ or folder if it does not exist, you will have to do so manually. If the file doe
 example file will be used.
 
 A limited number of properties can be set in the configuration, including the title and name of the
-xnat (DCAT) catalog and the publisher of the catalog. We are still working on adding more default
-values for certain DCAT properties to the configuration.
+xnat (DCAT) catalog and the publisher of the catalog. A default contact point for datasets can also
+be provided and will be included in the Dataset properties.
+We are still working on adding more default values for certain DCAT properties to the configuration.
 
 There is limited support for using environment variables. For setting the XNAT server, variables
 `XNAT_HOST` or `XNATPY_HOST` can be used, with the latter taking preference. Authentication can be

--- a/example-config.toml
+++ b/example-config.toml
@@ -2,6 +2,11 @@
 # optin = "include_catalog"
 # optout = "exclude_catalog"
 
+[dataset.contact_point]
+# override = true
+full_name = "Example Data Management office"
+email = "datamanager@example.com"
+
 [catalog]
 title = "Example XNAT catalog"
 description = "This is an example XNAT catalog description"

--- a/src/xnatdcat/dcat_model.py
+++ b/src/xnatdcat/dcat_model.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 class VCard(BaseModel):
     full_name: Optional[Literal] = None
-    uid: URIRef
+    uid: Optional[URIRef] = None
+    email: Optional[URIRef] = None
 
 
 def add_empty_node_of_type(graph: Graph, subject, predicate, node_type=None):
@@ -151,8 +152,13 @@ class DCATDataSet(BaseModel):
                         node_type=userinfo_format,
                     )
                     graph.add((vcard_node, VCARD.fn, item.full_name))
-                    graph.add((vcard_node, VCARD.hasUID, item.uid))
+                    if item.uid:
+                        graph.add((vcard_node, VCARD.hasUID, item.uid))
+                    if item.email:
+                        graph.add((vcard_node, VCARD.hasEmail, item.email))
+
             else:
+                logger.debug("User info is NOT of VCARD type")
                 for item in attribute:
                     if isinstance(item, VCard):
                         item = item.uid

--- a/src/xnatdcat/xnat_parser.py
+++ b/src/xnatdcat/xnat_parser.py
@@ -298,7 +298,12 @@ def contact_point_vcard_from_config(config: Dict) -> Union[VCard, None]:
         else:
             contact_email = URIRef(contact_config["email"])
     else:
-        contact_email = None
+        contact_email = contact_config.get("email")
+        if contact_email:
+            if not contact_email.startswith("mailto:"):
+                contact_email = f"mailto:{contact_email}"
+            contact_email = URIRef(contact_email)
+        return contact_email
 
     contact_vcard = VCard(full_name=Literal(contact_config["full_name"]), email=contact_email)
 

--- a/src/xnatdcat/xnat_parser.py
+++ b/src/xnatdcat/xnat_parser.py
@@ -1,4 +1,5 @@
 """Simple tool to query an XNAT instance and serialize projects as datasets"""
+
 import logging
 import re
 from typing import Dict, List, Union
@@ -291,19 +292,12 @@ def contact_point_vcard_from_config(config: Dict) -> Union[VCard, None]:
     except KeyError:
         return None
 
-    # email should be URIRef
-    if contact_config.get("email"):
-        if not contact_config["email"].startswith("mailto:"):
-            contact_email = URIRef(f"mailto:{contact_config['email']}")
-        else:
-            contact_email = URIRef(contact_config["email"])
-    else:
-        contact_email = contact_config.get("email")
-        if contact_email:
-            if not contact_email.startswith("mailto:"):
-                contact_email = f"mailto:{contact_email}"
-            contact_email = URIRef(contact_email)
-        return contact_email
+    # email should be URIRef (but not path, https://stackoverflow.com/a/27151227)
+    contact_email = contact_config.get("email")
+    if contact_email:
+        if not contact_email.startswith("mailto:"):
+            contact_email = f"mailto:{contact_email}"
+        contact_email = URIRef(contact_email)
 
     contact_vcard = VCard(full_name=Literal(contact_config["full_name"]), email=contact_email)
 

--- a/tests/references/no_contact_email.ttl
+++ b/tests/references/no_contact_email.ttl
@@ -11,6 +11,8 @@
     dcterms:identifier "test_xnatdcat"^^xsd:token ;
     dcterms:temporal [ a dcterms:PeriodOfTime ] ;
     dcterms:title "Basic test project to test the xnatdcat" ;
+    dcat:keyword "dcat",
+        "demo",
+        "test" ;
     dcat:contactPoint [ a vcard:VCard ;
-            vcard:fn "Example Data Management office" ;
-            vcard:hasEmail <mailto:datamanager@example.com> ] .
+            vcard:fn "Example Data Management office" ] .

--- a/tests/references/no_contactpoint.ttl
+++ b/tests/references/no_contactpoint.ttl
@@ -11,6 +11,6 @@
     dcterms:identifier "test_xnatdcat"^^xsd:token ;
     dcterms:temporal [ a dcterms:PeriodOfTime ] ;
     dcterms:title "Basic test project to test the xnatdcat" ;
-    dcat:contactPoint [ a vcard:VCard ;
-            vcard:fn "Example Data Management office" ;
-            vcard:hasEmail <mailto:datamanager@example.com> ] .
+    dcat:keyword "dcat",
+        "demo",
+        "test" .

--- a/tests/references/valid_project.ttl
+++ b/tests/references/valid_project.ttl
@@ -13,5 +13,7 @@
     dcterms:title "Basic test project to test the xnatdcat" ;
     dcat:keyword "dcat",
         "demo",
-        "test" .
-
+        "test" ;
+    dcat:contactPoint [ a vcard:VCard ;
+            vcard:fn "Example Data Management office" ;
+            vcard:hasEmail <mailto:datamanager@example.com> ] .

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -112,3 +112,58 @@ def test_no_keywords(project, empty_graph: Graph, config: Dict[str, Any]):
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_no_contactpoint(project, empty_graph: Graph, config: Dict[str, Any]):
+    """Test that there's no weird errors if there is no contactpoint"""
+    project.name = 'Basic test project to test the xnatdcat'
+    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
+    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
+    project.keywords = 'test demo dcat'
+    project.pi.firstname = 'Albus'
+    project.pi.lastname = 'Dumbledore'
+    project.pi.title = 'prof.'
+
+    del config['dataset']['contact_point']
+
+    empty_graph = empty_graph.parse(source='tests/references/no_contactpoint.ttl')
+    gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
+
+    assert to_isomorphic(empty_graph) == to_isomorphic(gen)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_email_uriref(project, empty_graph: Graph, config: Dict[str, Any]):
+    project.name = 'Basic test project to test the xnatdcat'
+    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
+    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
+    project.keywords = 'test demo dcat'
+    project.pi.firstname = 'Albus'
+    project.pi.lastname = 'Dumbledore'
+    project.pi.title = 'prof.'
+
+    config['dataset']['contact_point']['email'] = 'mailto:datamanager@example.com'
+
+    empty_graph = empty_graph.parse(source='tests/references/valid_project.ttl')
+    gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
+
+    assert to_isomorphic(empty_graph) == to_isomorphic(gen)
+
+
+@patch("xnat.core.XNATBaseObject")
+def test_no_email(project, empty_graph: Graph, config: Dict[str, Any]):
+    project.name = 'Basic test project to test the xnatdcat'
+    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
+    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
+    project.keywords = 'test demo dcat'
+    project.pi.firstname = 'Albus'
+    project.pi.lastname = 'Dumbledore'
+    project.pi.title = 'prof.'
+
+    del config['dataset']['contact_point']['email']
+
+    empty_graph = empty_graph.parse(source='tests/references/no_contact_email.ttl')
+    gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
+
+    assert to_isomorphic(empty_graph) == to_isomorphic(gen)

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -1,18 +1,19 @@
 from pathlib import Path
 from typing import Any, Dict
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib
 
-from rdflib import Graph, DCAT, DCTERMS
+from rdflib import DCAT, DCTERMS, Graph
 from rdflib.compare import to_isomorphic
 
-from xnatdcat.xnat_parser import xnat_to_RDF, xnat_to_DCATDataset, VCARD
 from xnatdcat.const import EXAMPLE_CONFIG_PATH
+from xnatdcat.xnat_parser import VCARD, xnat_to_DCATDataset, xnat_to_RDF
 
 
 # Taken from cedar2fdp
@@ -30,7 +31,7 @@ def config():
     """Loads the default configuration TOML"""
     config_path = EXAMPLE_CONFIG_PATH
 
-    with open(config_path, 'rb') as f:
+    with open(config_path, "rb") as f:
         config = tomllib.load(f)
 
     return config
@@ -41,9 +42,9 @@ def test_empty_xnat(session, empty_graph: Graph, config: Dict[str, Any]):
     """Test case for an XNAT with no projects at all"""
     # XNATSession is a key-value store so pretent it is a Dict
     session.projects = {}
-    session.url_for.return_value = 'https://xnat.bmia.nl'
+    session.url_for.return_value = "https://xnat.bmia.nl"
 
-    empty_graph = empty_graph.parse(source='tests/references/empty_xnat.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/empty_xnat.ttl")
 
     expected = xnat_to_RDF(session, config)
 
@@ -54,15 +55,15 @@ def test_empty_xnat(session, empty_graph: Graph, config: Dict[str, Any]):
 @patch("xnat.core.XNATBaseObject")
 def test_valid_project(project, empty_graph: Graph, config: Dict[str, Any]):
     """Test if a valid project generates valid output"""
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
-    empty_graph = empty_graph.parse(source='tests/references/valid_project.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/valid_project.ttl")
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
@@ -71,13 +72,13 @@ def test_valid_project(project, empty_graph: Graph, config: Dict[str, Any]):
 @patch("xnat.core.XNATBaseObject")
 def test_empty_description(project, config: Dict[str, Any]):
     """Test if a valid project generates valid output"""
-    project.name = 'Basic test project to test the xnatdcat'
+    project.name = "Basic test project to test the xnatdcat"
     project.description = None
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
     with pytest.raises(ValueError):
         xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
@@ -86,10 +87,10 @@ def test_empty_description(project, config: Dict[str, Any]):
 @patch("xnat.core.XNATBaseObject")
 def test_invalid_PI(project, config: Dict[str, Any]):
     """Make sure if PI field is invalid, an exception is raised"""
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
     project.pi.firstname = None
     project.pi.lastname = None
 
@@ -100,15 +101,15 @@ def test_invalid_PI(project, config: Dict[str, Any]):
 @patch("xnat.core.XNATBaseObject")
 def test_no_keywords(project, empty_graph: Graph, config: Dict[str, Any]):
     """Valid project without keywords, make sure it is not defined in output"""
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = ''
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = ""
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
-    empty_graph = empty_graph.parse(source='tests/references/no_keyword.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/no_keyword.ttl")
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
@@ -117,17 +118,17 @@ def test_no_keywords(project, empty_graph: Graph, config: Dict[str, Any]):
 @patch("xnat.core.XNATBaseObject")
 def test_no_contactpoint(project, empty_graph: Graph, config: Dict[str, Any]):
     """Test that there's no weird errors if there is no contactpoint"""
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
-    del config['dataset']['contact_point']
+    del config["dataset"]["contact_point"]
 
-    empty_graph = empty_graph.parse(source='tests/references/no_contactpoint.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/no_contactpoint.ttl")
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
@@ -135,17 +136,17 @@ def test_no_contactpoint(project, empty_graph: Graph, config: Dict[str, Any]):
 
 @patch("xnat.core.XNATBaseObject")
 def test_email_uriref(project, empty_graph: Graph, config: Dict[str, Any]):
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
-    config['dataset']['contact_point']['email'] = 'mailto:datamanager@example.com'
+    config["dataset"]["contact_point"]["email"] = "mailto:datamanager@example.com"
 
-    empty_graph = empty_graph.parse(source='tests/references/valid_project.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/valid_project.ttl")
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
@@ -153,17 +154,17 @@ def test_email_uriref(project, empty_graph: Graph, config: Dict[str, Any]):
 
 @patch("xnat.core.XNATBaseObject")
 def test_no_email(project, empty_graph: Graph, config: Dict[str, Any]):
-    project.name = 'Basic test project to test the xnatdcat'
-    project.description = 'In this project, we test xnat and dcat and make sure a description appears.'
-    project.external_uri.return_value = 'http://localhost/data/archive/projects/test_xnatdcat'
-    project.keywords = 'test demo dcat'
-    project.pi.firstname = 'Albus'
-    project.pi.lastname = 'Dumbledore'
-    project.pi.title = 'prof.'
+    project.name = "Basic test project to test the xnatdcat"
+    project.description = "In this project, we test xnat and dcat and make sure a description appears."
+    project.external_uri.return_value = "http://localhost/data/archive/projects/test_xnatdcat"
+    project.keywords = "test demo dcat"
+    project.pi.firstname = "Albus"
+    project.pi.lastname = "Dumbledore"
+    project.pi.title = "prof."
 
-    del config['dataset']['contact_point']['email']
+    del config["dataset"]["contact_point"]["email"]
 
-    empty_graph = empty_graph.parse(source='tests/references/no_contact_email.ttl')
+    empty_graph = empty_graph.parse(source="tests/references/no_contact_email.ttl")
     gen = xnat_to_DCATDataset(project, config).to_graph(userinfo_format=VCARD.VCard)
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)


### PR DESCRIPTION
As a data management office, I want to be the central contact point for all data requests instead of the PI. Therefore, I want to set the same contact data for all datasets that I am publishing. But not every data management office wants this.

Acceptance criteria:
* A central contact point can be set in the settings (name / email)
* The contact information will be published as metadata in the dataset.
* There is a setting determining if already-existing information will be overridden or not.