### PR TITLE
chore(docker): harden python 3.12 base image for snyk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,25 @@ FROM python:3.12-alpine3.22 AS img2catalog
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
-RUN apk update \
-	&& apk upgrade \
-	&& rm -rf /var/cache/apk/*
-
-RUN pip install --no-cache-dir .
-
 # Latest releases and checksums available at https://github.com/aptible/supercronic/releases
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.44/supercronic-linux-amd64 \
     SUPERCRONIC_SHA256SUM=6feff7d5eba16a89cf229b7eb644cfae2f03a32c62ca320f17654659315275b6 \
     SUPERCRONIC=supercronic-linux-amd64
 
-RUN apk add --no-cache curl \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA256SUM}  ${SUPERCRONIC}" | sha256sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -sf "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic \
- && apk del curl
-
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+
+RUN apk update \
+	&& apk upgrade \
+	&& rm -rf /var/cache/apk/*\
+    && pip install --no-cache-dir . \
+    && apk add --no-cache curl \
+    && curl -fsSLO "$SUPERCRONIC_URL" \
+    && echo "${SUPERCRONIC_SHA256SUM}  ${SUPERCRONIC}" | sha256sum -c - \
+    && chmod +x "$SUPERCRONIC" \
+    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+    && ln -sf "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic \
+    && apk del curl\
+    && chmod +x /usr/local/bin/entrypoint.sh
 
 RUN adduser -D app
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN apk update \
     && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
     && ln -sf "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic \
     && apk del curl\
-    && chmod +x /usr/local/bin/entrypoint.sh
+    && chmod +x /usr/local/bin/entrypoint.sh \
+    && adduser -D app
 
-RUN adduser -D app
 USER app
 WORKDIR /home/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.12-slim AS img2catalog
+FROM python:3.12-alpine3.22 AS img2catalog
 
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
+RUN apk update \
+	&& apk upgrade \
+	&& rm -rf /var/cache/apk/*
+
 RUN pip install --no-cache-dir .
 
-RUN useradd -m app
+RUN adduser -D app
 USER app
 WORKDIR /home/app
 

--- a/tests/img2catalog/xnatpy_fixtures.py
+++ b/tests/img2catalog/xnatpy_fixtures.py
@@ -34,6 +34,11 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# XNATPy can call logger.verbose() on custom loggers.
+# Standard Python loggers do not provide this method, so add a safe alias for tests.
+if not hasattr(logger, "verbose"):
+    logger.verbose = logger.debug
+
 class CreatedObject:
     def __init__(self, uri, type_, fieldname, **kwargs):
         self.uri = uri


### PR DESCRIPTION
This pull request updates the Docker build process and improves test compatibility with custom logging. The most significant changes include switching to an Alpine-based Python image for the Docker build and ensuring test loggers are compatible with XNATPy's logging expectations.

**Docker build improvements:**

* Switched the base image in `Dockerfile` from `python:3.12-slim` to `python:3.12-alpine3.22` for a smaller and potentially more secure image, and updated the user creation command to use Alpine's `adduser`. Also added explicit `apk update` and `apk upgrade` steps for package freshness.

**Test logging compatibility:**

* In `tests/img2catalog/xnatpy_fixtures.py`, added a `verbose` alias to the logger if it doesn't exist, ensuring compatibility with XNATPy's custom logging calls during tests.

_The help of Github Copilot was used in making this PR_